### PR TITLE
Remove active color

### DIFF
--- a/lib/NavItem/nav-item.css
+++ b/lib/NavItem/nav-item.css
@@ -20,6 +20,3 @@ html[data-whatinput="mouse"] .nav-item > div > :first-child:focus {
   display: inline-block;
   padding: 2rem;
 }
-.nav-item.active > div {
-  color: #fff;
-}

--- a/lib/NavItem/nav-item.js
+++ b/lib/NavItem/nav-item.js
@@ -35,16 +35,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  */
 function NavItem(_ref) {
   var children = _ref.children;
-  var active = _ref.active;
   var styles = _ref.styles;
-  var other = (0, _objectWithoutProperties3.default)(_ref, ['children', 'active', 'styles']);
-
-  var styleName = active ? 'nav-item active' : 'nav-item';
+  var other = (0, _objectWithoutProperties3.default)(_ref, ['children', 'styles']);
 
   return _react2.default.createElement(
     'li',
     (0, _extends3.default)({
-      styleName: styleName
+      styleName: 'nav-item'
     }, other),
     _react2.default.createElement(
       'div',

--- a/lib/NavItem/nav-item.styl
+++ b/lib/NavItem/nav-item.styl
@@ -23,6 +23,3 @@ html
     > :first-child
       display: inline-block
       padding: 2rem
-
-  &.active > div
-    color: white

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emsi-ui",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "UI components for use within Emsi",
   "main": "./public/bundle.js",
   "scripts": {

--- a/src/components/NavItem/nav-item.js
+++ b/src/components/NavItem/nav-item.js
@@ -5,8 +5,6 @@ import CSSModules from 'react-css-modules';
 import cx from 'classnames';
 
 type Props = {
-  /** adds the active class, when true */
-  active?: boolean,
   /** position the active class on the bottom or top of the text */
   styles: Object,
 
@@ -15,12 +13,10 @@ type Props = {
 /**
  * Tab can't be used outside the TabPanel Component context
  */
-function NavItem({ children, active, styles, ...other }: Props) {
-  const styleName = active ? 'nav-item active' : 'nav-item';
-
+function NavItem({ children, styles, ...other }: Props) {
   return (
     <li
-      styleName={styleName}
+      styleName='nav-item'
       {...other}
     >
       <div>

--- a/src/components/NavItem/nav-item.styl
+++ b/src/components/NavItem/nav-item.styl
@@ -23,6 +23,3 @@ html
     > :first-child
       display: inline-block
       padding: 2rem
-
-  &.active > div
-    color: white


### PR DESCRIPTION
- removed the hard coded active color from the nav item component, doesn't look so good for clients that have a white background
- https://bhcc.emsicc.com/ and go to `explore-careers` the nav item `careers` will go bye bye.